### PR TITLE
fix(security): update SecurityHeadersMiddleware to OWASP API standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.1.1] - 2025-11-28
+
+### Changed
+- **SecurityHeadersMiddleware**: Simplified Content-Security-Policy to `frame-ancestors 'none'` for better API security and Swagger UI compatibility
+- **SecurityHeadersMiddleware**: Updated default headers to match OWASP API security best practices
+- **SecurityHeadersMiddleware**: Fixed header processing order - now removes server identification headers before building existing headers set
+- **SecurityHeadersMiddleware**: Added duplicate header prevention - checks if headers already exist before adding
+
+### Added
+- **SecurityHeadersMiddleware**: Now includes `Cache-Control: no-store, max-age=0` by default
+- **SecurityHeadersMiddleware**: Now includes `Referrer-Policy: no-referrer` by default
+- **SecurityHeadersMiddleware**: Now includes `Permissions-Policy: geolocation=(), microphone=(), camera=()` by default
+- Automatic removal of `Server` and `X-Powered-By` headers to reduce information disclosure
+
+### Removed
+- **SecurityHeadersMiddleware**: Removed `X-XSS-Protection` header (deprecated and not recommended: [MDN Reference](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/X-XSS-Protection))
+- **SecurityHeadersMiddleware**: Removed complex CSP with script/style/img sources (not needed for APIs)
+
+## [0.1.0] - 2025-11-21
 
 ### Added
 - Initial release of FastAPI Middlewares
@@ -18,11 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test suite with 100% coverage
 - Example application
 - Documentation and contributing guidelines
-
-## [0.1.0] - 2025-11-21
-
-### Added
-- Initial release
 
 [Unreleased]: https://github.com/mahdijafaridev/fastapi-middlewares/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/mahdijafaridev/fastapi-middlewares/releases/tag/v0.1.0


### PR DESCRIPTION
- Simplified CSP for API security and Swagger compatibility
- Added Cache-Control, Referrer-Policy, Permissions-Policy
- Removed deprecated X-XSS-Protection
- Fixed header processing order bug
- Added duplicate header prevention
- Updated documentation

BREAKING CHANGE: Default security headers changed