### PR TITLE
3 question   logging streaming responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [0.2.0] - 2025-12-04
+
+### Added
+- **LoggingMiddleware**: Streaming response body logging for complete response capture after streaming
+- **LoggingMiddleware**: `log_response_body` parameter to enable response body logging (default: False)
+- **LoggingMiddleware**: `log_response_body_paths` parameter for path-specific body logging
+- **LoggingMiddleware**: `max_body_length` parameter to limit memory usage (default: 1000 characters)
+- **LoggingMiddleware**: Automatic truncation when response exceeds max_body_length
+- **LoggingMiddleware**: Smart content-type detection (text/JSON/binary)
+- **LoggingMiddleware**: UTF-8 decode error handling for malformed responses
+- **LoggingMiddleware**: Memory-efficient buffering that stops at limit
+- Comprehensive test coverage for all streaming edge cases
+
+### Changed
+- **LoggingMiddleware**: `max_body_length` now represents characters (post UTF-8 decode), not bytes
+- **LoggingMiddleware**: Empty streaming responses no longer logged
+- **LoggingMiddleware**: Binary responses log metadata only (size, content-type)
+
+### Fixed
+- **LoggingMiddleware**: Memory leak prevention for large streaming responses
+- **LoggingMiddleware**: Proper handling of empty chunks in streams
+- **LoggingMiddleware**: Case-insensitive Content-Type header detection
+- **LoggingMiddleware**: Correct logging when truncation occurs with no captured content
+
 ## [0.1.1] - 2025-11-28
 
 ### Changed
@@ -37,5 +62,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Example application
 - Documentation and contributing guidelines
 
-[Unreleased]: https://github.com/mahdijafaridev/fastapi-middlewares/compare/v0.1.0...HEAD
+[0.2.0]: https://github.com/mahdijafaridev/fastapi-middlewares/compare/v0.2.0...HEAD
+[0.1.1]: https://github.com/mahdijafaridev/fastapi-middlewares/releases/tag/v0.1.1
 [0.1.0]: https://github.com/mahdijafaridev/fastapi-middlewares/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Essential middlewares for FastAPI applications.
 
 [![CI](https://github.com/mahdijafaridev/fastapi-middlewares/actions/workflows/ci.yml/badge.svg)](https://github.com/mahdijafaridev/fastapi-middlewares/actions/workflows/ci.yml)
+[![security: bandit](https://img.shields.io/badge/security-bandit-yellow.svg)](https://github.com/PyCQA/bandit)
 [![PyPI Version](https://img.shields.io/pypi/v/fastapi-middlewares.svg)](https://pypi.org/project/fastapi-middlewares/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/fastapi-middlewares.svg)](https://pypi.org/project/fastapi-middlewares/)
 [![Downloads](https://static.pepy.tech/badge/fastapi-middlewares)](https://pepy.tech/project/fastapi-middlewares)
@@ -184,10 +185,10 @@ app = FastAPI()
 app.add_middleware(
     LoggingMiddleware,
     log_response_body=True,  # Enable body logging
-    max_body_length=500,     # The maximum characters to log for body (default: 1000)
+    max_body_length=500,      # The maximum number of characters (after UTF-8 decoding) to log for body (default: 1000)
 )
 
-# NOTE: Be cautious of setting max body length since it uses memory to buffer the response.
+# NOTE: Be cautious of setting a HIGH max body length, as large values use more memory to buffer the response. Small values help prevent excessive memory usage.
 
 @app.get("/ai/chat")
 async def ai_chat():

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 Essential middlewares for FastAPI applications.
 
-
 [![CI](https://github.com/mahdijafaridev/fastapi-middlewares/actions/workflows/ci.yml/badge.svg)](https://github.com/mahdijafaridev/fastapi-middlewares/actions/workflows/ci.yml)
-[![PyPI Downloads](https://static.pepy.tech/personalized-badge/fastapi-middlewares?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/fastapi-middlewares)[![PyPI version](https://badge.fury.io/py/fastapi-middlewares.svg)](https://badge.fury.io/py/fastapi-middlewares)
+[![PyPI Version](https://img.shields.io/pypi/v/fastapi-middlewares.svg)](https://pypi.org/project/fastapi-middlewares/)
 [![Python Versions](https://img.shields.io/pypi/pyversions/fastapi-middlewares.svg)](https://pypi.org/project/fastapi-middlewares/)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Downloads](https://static.pepy.tech/badge/fastapi-middlewares)](https://pepy.tech/project/fastapi-middlewares)
+[![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Features
 
@@ -14,6 +14,7 @@ Essential middlewares for FastAPI applications.
 - ⏱️ **Request Timing** - Measure response times
 - 🔒 **Security Headers** - OWASP-compliant security headers
 - 📝 **Structured Logging** - JSON-formatted request/response logs
+- 🌊 **Streaming Response Logging** - Log complete streamed responses (perfect for AI/LLM apps)
 - 🚨 **Error Handling** - Graceful error responses with tracebacks
 - ⚡ **Easy Setup** - One-line configuration with sensible defaults
 
@@ -166,6 +167,58 @@ app.add_middleware(
 **Options:**
 - `logger_name`: Logger name (default: "fastapi_middlewares")
 - `skip_paths`: Paths to skip logging (default: ["/health", "/metrics"])
+- `log_response_body`: Enable response body logging (default: False)
+- `max_body_length`: Maximum response body length to log (default: 1000)
+
+#### Streaming Response Logging (NEW)
+
+Perfect for AI/LLM applications! The middleware can now log the complete streamed response after streaming finishes.
+
+```python
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+from middlewares import LoggingMiddleware
+
+app = FastAPI()
+
+app.add_middleware(
+    LoggingMiddleware,
+    log_response_body=True,  # Enable body logging
+    max_body_length=500,     # The maximum characters to log for body (default: 1000)
+)
+
+# NOTE: Be cautious of setting max body length since it uses memory to buffer the response.
+
+@app.get("/ai/chat")
+async def ai_chat():
+    async def generate():
+        # Simulate streaming AI response
+        for word in "Hello from AI assistant!".split():
+            yield word + " "
+    
+    return StreamingResponse(generate(), media_type="text/plain")
+```
+
+**What gets logged:**
+- The complete response after all chunks are sent
+- Truncated if longer than `max_body_length`
+- Only text-based responses (JSON, HTML, text)
+- Binary responses only log size and content type
+
+**Log output:**
+```json
+{
+  "request_id": "550e8400-...",
+  "body": "Hello from AI assistant! ",
+  "truncated": false
+}
+```
+
+**Use cases:**
+- Debugging AI/LLM streaming responses
+- Monitoring chatbot conversations
+- Auditing API responses
+- Testing streaming endpoints
 
 ### 5. Error Handling Middleware
 
@@ -279,6 +332,7 @@ app.add_middleware(ErrorHandlingMiddleware) # 1. Catch errors (outermost)
 
 ```python
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse
 from middlewares import add_essentials
 
 app = FastAPI(title="My API")
@@ -288,7 +342,9 @@ add_essentials(
     app,
     cors_origins=["http://localhost:3000"],
     include_traceback=False,  # Set True for development
-    logger_name="my_api"
+    logger_name="my_api",
+    log_response_body=True,   # NEW: Log response bodies
+    max_body_length=500,      # NEW: max body length in characters
 )
 
 @app.get("/")
@@ -300,6 +356,15 @@ def get_user(user_id: int):
     if user_id < 1:
         raise ValueError("Invalid user ID")
     return {"user_id": user_id, "name": "John"}
+
+@app.get("/ai/chat")
+async def ai_chat():
+    """Streaming AI endpoint - response will be logged!"""
+    async def generate():
+        for word in "This is a streaming AI response".split():
+            yield word + " "
+    
+    return StreamingResponse(generate(), media_type="text/plain")
 
 @app.get("/error")
 def error():
@@ -316,14 +381,10 @@ Test it:
 # Check headers
 curl -I http://localhost:8000/
 
-# Expected headers:
-# X-Request-ID: 550e8400-...
-# X-Process-Time: 0.0245
-# X-Content-Type-Options: nosniff
-# X-Frame-Options: DENY
-# Cache-Control: no-store, max-age=0
-# Content-Security-Policy: frame-ancestors 'none'
-# Referrer-Policy: no-referrer
+# Test streaming with body logging
+curl http://localhost:8000/ai/chat
+
+# Check logs to see the complete streamed response
 ```
 
 ## Development

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,12 +41,19 @@ Adds OWASP-recommended security headers to all responses.
 - Content type sniffing prevention
 
 ### LoggingMiddleware
-Structured JSON logging for all requests and responses.
+Structured JSON logging for all requests and responses with streaming support.
 
 **Use cases:**
 - Centralized logging systems
 - Request auditing
 - Performance analysis
+- **NEW: AI/LLM response monitoring**
+
+**Features:**
+- Complete streaming response logging
+- Automatic truncation for memory safety
+- Binary content detection
+- UTF-8 decode error handling
 
 ### ErrorHandlingMiddleware
 Catches exceptions and returns well-formatted error responses.

--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -21,7 +21,7 @@ add_essentials(
     include_traceback=True,  # Set to False in production
     logger_name="example_app",
     log_response_body=True,  # Enable response body logging
-    max_body_length=500,     # Limit logged body size. Beware of memory usage!
+    max_body_length=500,     # Limit logged body size to 500 characters. Beware: larger values increase memory usage!
 )
 
 

--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -21,7 +21,7 @@ add_essentials(
     include_traceback=True,  # Set to False in production
     logger_name="example_app",
     log_response_body=True,  # Enable response body logging
-    max_body_length=500,     # Limit logged body size to 500 characters. Beware: larger values increase memory usage!
+    max_body_length=500,  # Max body length in characters (after UTF-8 decode). Keep ≤5000 for production.
 )
 
 
@@ -96,7 +96,8 @@ async def stream_example():
 
 @app.get("/ai/chat")
 async def ai_chat_simulation():
-    """Simulate AI/LLM streaming response (like OpenAI's ChatGPT)."""
+    """Simulate AI/LLM streaming response - complete response will be logged after streaming."""
+
     async def generate():
         response = "This is a simulated LLM/AI/ML response. The middleware will log the complete response after streaming finishes. This is useful for debugging and monitoring AI/LLM/ML applications."
 
@@ -151,10 +152,12 @@ if __name__ == "__main__":
     print("  curl http://localhost:8000/stream")
     print("  curl http://localhost:8000/ai/chat")
     print("  curl -H 'Accept-Encoding: gzip' http://localhost:8000/large")
-    print("\nNEW FEATURE - Response Body Logging:")
-    print("  The complete streaming response is now logged after streaming completes")
-    print("  Check the console logs to see the full response body")
-    print("  Especially useful for AI/LLM endpoints!")
+    print("\nStreaming Response Body Logging:")
+    print("  ✓ Complete streamed responses logged after streaming finishes")
+    print("  ✓ Handles text, JSON, and binary content automatically")
+    print("  ✓ Truncates at max_body_length to prevent memory issues")
+    print("  ✓ Perfect for debugging AI/LLM streaming endpoints")
+    print("  Check console logs after calling /stream or /ai/chat")
     print("\nCheck the response headers for:")
     print("  - X-Request-ID: Unique request identifier")
     print("  - X-Process-Time: Request processing time")

--- a/examples/example_app.py
+++ b/examples/example_app.py
@@ -1,14 +1,18 @@
 """Example FastAPI app using all middlewares."""
 
+import asyncio
 import logging
 
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from middlewares import add_essentials
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s")
 
 app = FastAPI(
-    title="FastAPI Middlewares Example", description="Example app showing all middlewares in action", version="1.0.0"
+    title="FastAPI Middlewares Example",
+    description="Example app showing all middlewares in action",
+    version="1.0.0"
 )
 
 add_essentials(
@@ -16,6 +20,8 @@ add_essentials(
     cors_origins=["http://localhost:3000", "http://localhost:5173"],
     include_traceback=True,  # Set to False in production
     logger_name="example_app",
+    log_response_body=True,  # Enable response body logging
+    max_body_length=500,     # Limit logged body size. Beware of memory usage!
 )
 
 
@@ -30,6 +36,8 @@ def root(request: Request):
             "health": "/health",
             "users": "/users/{user_id}",
             "items": "/items?limit=10",
+            "stream": "/stream",
+            "ai_chat": "/ai/chat",
             "error": "/error",
             "not_found": "/not-found",
             "slow": "/slow",
@@ -74,6 +82,32 @@ def create_item(item: dict):
     return {"message": "Item created", "item": item, "id": 123}
 
 
+@app.get("/stream")
+async def stream_example():
+    """Example streaming endpoint (response body will be logged)."""
+    async def generate():
+        for i in range(5):
+            yield f"Chunk {i + 1}\n"
+            await asyncio.sleep(0.1)
+        yield "Stream complete!\n"
+
+    return StreamingResponse(generate(), media_type="text/plain")
+
+
+@app.get("/ai/chat")
+async def ai_chat_simulation():
+    """Simulate AI/LLM streaming response (like OpenAI's ChatGPT)."""
+    async def generate():
+        response = "This is a simulated LLM/AI/ML response. The middleware will log the complete response after streaming finishes. This is useful for debugging and monitoring AI/LLM/ML applications."
+
+        words = response.split()
+        for word in words:
+            yield word + " "
+            await asyncio.sleep(0.05)
+
+    return StreamingResponse(generate(), media_type="text/plain")
+
+
 @app.get("/error")
 def trigger_error():
     """Endpoint that raises an error (for testing error handling)."""
@@ -114,7 +148,13 @@ if __name__ == "__main__":
     print("  curl -I http://localhost:8000/users/1")
     print("  curl http://localhost:8000/error")
     print("  curl http://localhost:8000/slow")
+    print("  curl http://localhost:8000/stream")
+    print("  curl http://localhost:8000/ai/chat")
     print("  curl -H 'Accept-Encoding: gzip' http://localhost:8000/large")
+    print("\nNEW FEATURE - Response Body Logging:")
+    print("  The complete streaming response is now logged after streaming completes")
+    print("  Check the console logs to see the full response body")
+    print("  Especially useful for AI/LLM endpoints!")
     print("\nCheck the response headers for:")
     print("  - X-Request-ID: Unique request identifier")
     print("  - X-Process-Time: Request processing time")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
 ]
 license = {text = "MIT"}
 dependencies = [
+    "bandit>=1.9.2",
     "build>=1.3.0",
     "fastapi>=0.121.0",
     "starlette>=0.50.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fastapi-middlewares"
-version = "0.1.1"
+version = "0.2.0"
 description = "Essential middlewares for FastAPI"
 readme = "README.md"
 authors = [

--- a/tests/test_middlewares.py
+++ b/tests/test_middlewares.py
@@ -1,8 +1,12 @@
+import json
 import logging
+import time
+import uuid
 from collections import Counter
+from collections.abc import AsyncGenerator, Callable
 
 import pytest
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 from starlette.responses import JSONResponse, StreamingResponse
 
@@ -17,50 +21,102 @@ from middlewares import (
     add_gzip,
 )
 
+# ============================================================================
+# Fixtures
+# ============================================================================
+
 
 @pytest.fixture
-def app():
+def app() -> FastAPI:
     """Create a FastAPI app for each test."""
     return FastAPI()
 
 
 @pytest.fixture
-def client(app):
+def client(app: FastAPI) -> TestClient:
     """Create test client."""
     return TestClient(app)
+
+
+# ============================================================================
+# Test Helpers
+# ============================================================================
+
+
+def assert_valid_uuid(value: str) -> None:
+    """Assert that a string is a valid UUID."""
+    try:
+        uuid.UUID(value)
+    except ValueError:
+        pytest.fail(f"'{value}' is not a valid UUID")
+
+
+def add_route(app: FastAPI, path: str = "/test", handler: Callable | None = None) -> None:
+    """Add a simple test route to the app."""
+    if handler is None:
+
+        def handler():
+            return {"status": "ok"}
+
+    app.get(path)(handler)
+
+
+def add_slow_route(app: FastAPI, delay: float = 0.1) -> None:
+    """Add a route with artificial delay."""
+
+    def slow_handler():
+        time.sleep(delay)
+        return {"status": "ok"}
+
+    app.get("/slow")(slow_handler)
+
+
+def add_error_route(app: FastAPI, exception: Exception) -> None:
+    """Add a route that raises an exception."""
+
+    def error_handler():
+        raise exception
+
+    app.get("/error")(error_handler)
+
+
+async def create_streaming_generator(chunks: list[bytes]) -> AsyncGenerator[bytes, None]:
+    """Create an async generator for streaming responses."""
+    for chunk in chunks:
+        yield chunk
+
+
+def get_logs(caplog, logger_name: str, filter_text: str = "") -> list[str]:
+    """Extract log messages from caplog for a specific logger."""
+    messages = [record.message for record in caplog.records if record.name == logger_name]
+    if filter_text:
+        messages = [msg for msg in messages if filter_text in msg]
+    return messages
+
+
+# ============================================================================
+# RequestID Middleware Tests
+# ============================================================================
 
 
 class TestRequestIDMiddleware:
     """Test RequestID middleware."""
 
-    def test_generates_request_id(self, app, client):
-        """Test that middleware generates a unique request ID."""
+    def test_generates_unique_request_id(self, app, client):
+        """Middleware should generate a valid UUID for each request."""
         app.add_middleware(RequestIDMiddleware)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test")
 
         assert response.status_code == 200
         assert "x-request-id" in response.headers
-        assert len(response.headers["x-request-id"]) > 0
+        assert_valid_uuid(response.headers["x-request-id"])
 
-        import uuid
-
-        try:
-            uuid.UUID(response.headers["x-request-id"])
-        except ValueError:
-            pytest.fail("Request ID is not a valid UUID")
-
-    def test_uses_existing_request_id(self, app, client):
-        """Test that middleware preserves existing request ID from headers."""
+    def test_preserves_existing_request_id(self, app, client):
+        """Middleware should use request ID from incoming headers."""
         app.add_middleware(RequestIDMiddleware)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         custom_id = "custom-test-id-123"
         response = client.get("/test", headers={"X-Request-ID": custom_id})
@@ -68,48 +124,45 @@ class TestRequestIDMiddleware:
         assert response.headers["x-request-id"] == custom_id
 
     def test_custom_header_name(self, app, client):
-        """Test that middleware works with custom header name."""
+        """Middleware should work with custom header names."""
         app.add_middleware(RequestIDMiddleware, header_name="X-Custom-ID")
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test")
 
         assert "x-custom-id" in response.headers
         assert "x-request-id" not in response.headers
 
-    def test_request_id_in_scope(self, app, client):
-        """Test that request ID is stored in scope for use by other middleware."""
-        from fastapi import Request
-
+    def test_request_id_available_in_scope(self, app, client):
+        """Request ID should be accessible in request scope."""
         app.add_middleware(RequestIDMiddleware)
 
-        request_id_from_scope = None
+        captured_id = None
 
-        @app.get("/test")
-        def test_route(request: Request):
-            nonlocal request_id_from_scope
-            request_id_from_scope = request.scope.get("request_id")
+        def handler(request: Request):
+            nonlocal captured_id
+            captured_id = request.scope.get("request_id")
             return {"status": "ok"}
 
+        add_route(app, handler=handler)
         response = client.get("/test")
 
-        assert request_id_from_scope is not None
-        assert request_id_from_scope == response.headers["x-request-id"]
+        assert captured_id is not None
+        assert captured_id == response.headers["x-request-id"]
+
+
+# ============================================================================
+# RequestTiming Middleware Tests
+# ============================================================================
 
 
 class TestRequestTimingMiddleware:
     """Test RequestTiming middleware."""
 
     def test_adds_timing_header(self, app, client):
-        """Test that middleware adds process time header."""
+        """Middleware should add process time header with valid value."""
         app.add_middleware(RequestTimingMiddleware)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test")
 
@@ -117,33 +170,22 @@ class TestRequestTimingMiddleware:
         assert "x-process-time" in response.headers
 
         timing = float(response.headers["x-process-time"])
-        assert timing >= 0
-        assert timing < 1.0  # Should be very fast for simple endpoint
+        assert 0 <= timing < 1.0
 
     def test_timing_accuracy(self, app, client):
-        """Test that timing is reasonably accurate."""
-        import time
-
+        """Process time should accurately reflect request duration."""
         app.add_middleware(RequestTimingMiddleware)
-
-        @app.get("/slow")
-        def slow_route():
-            time.sleep(0.1)  # 100ms delay
-            return {"status": "ok"}
+        add_slow_route(app, delay=0.1)
 
         response = client.get("/slow")
-
         timing = float(response.headers["x-process-time"])
-        assert timing >= 0.1  # At least 100ms
-        assert timing < 0.5  # Allow overhead on CI systems
+
+        assert 0.1 <= timing < 0.5  # Allow CI overhead
 
     def test_custom_header_name(self, app, client):
-        """Test that middleware works with custom header name."""
+        """Middleware should support custom header names."""
         app.add_middleware(RequestTimingMiddleware, header_name="X-Duration")
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test")
 
@@ -151,552 +193,302 @@ class TestRequestTimingMiddleware:
         assert "x-process-time" not in response.headers
 
 
+# ============================================================================
+# SecurityHeaders Middleware Tests
+# ============================================================================
+
+
 class TestSecurityHeadersMiddleware:
     """Test SecurityHeaders middleware."""
 
-    def test_adds_all_default_security_headers(self, app, client):
-        """Test that all default security headers are added."""
-        app.add_middleware(SecurityHeadersMiddleware)
+    DEFAULT_HEADERS = {
+        "cache-control": "no-store, max-age=0",
+        "content-security-policy": "frame-ancestors 'none'",
+        "x-content-type-options": "nosniff",
+        "x-frame-options": "DENY",
+        "referrer-policy": "no-referrer",
+        "permissions-policy": "geolocation=(), microphone=(), camera=()",
+    }
 
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+    def test_adds_all_default_headers(self, app, client):
+        """Middleware should add all default security headers."""
+        app.add_middleware(SecurityHeadersMiddleware)
+        add_route(app)
 
         response = client.get("/test")
 
-        assert response.status_code == 200
+        for header, expected_value in self.DEFAULT_HEADERS.items():
+            assert response.headers.get(header) == expected_value
 
-        # Verify all default headers are present with correct values
-        assert "cache-control" in response.headers
-        assert response.headers["cache-control"] == "no-store, max-age=0"
-
-        assert "content-security-policy" in response.headers
-        assert response.headers["content-security-policy"] == "frame-ancestors 'none'"
-
-        assert "x-content-type-options" in response.headers
-        assert response.headers["x-content-type-options"] == "nosniff"
-
-        assert "x-frame-options" in response.headers
-        assert response.headers["x-frame-options"] == "DENY"
-
-        assert "referrer-policy" in response.headers
-        assert response.headers["referrer-policy"] == "no-referrer"
-
-        assert "permissions-policy" in response.headers
-        assert response.headers["permissions-policy"] == "geolocation=(), microphone=(), camera=()"
-
-    def test_removes_server_identification_headers(self, app, client):
-        """Test that Server and X-Powered-By headers are removed."""
+    def test_removes_server_identification(self, app, client):
+        """Middleware should remove server identification headers."""
         app.add_middleware(SecurityHeadersMiddleware)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test")
 
-        # Verify server identification headers are removed
         assert "server" not in response.headers
         assert "x-powered-by" not in response.headers
 
     def test_hsts_added_for_https(self, app, client):
-        """Test HSTS header is added for HTTPS connections."""
+        """HSTS header should be added for HTTPS connections."""
         app.add_middleware(SecurityHeadersMiddleware, hsts_max_age=63072000)
+        add_route(app)
 
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
-
-        # Simulate HTTPS request via proxy
         response = client.get("/test", headers={"X-Forwarded-Proto": "https"})
 
-        assert "strict-transport-security" in response.headers
         assert response.headers["strict-transport-security"] == "max-age=63072000; includeSubDomains"
 
     def test_hsts_not_added_for_http(self, app, client):
-        """Test HSTS header is NOT added for HTTP connections."""
+        """HSTS header should not be added for HTTP connections."""
         app.add_middleware(SecurityHeadersMiddleware)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test")
 
-        # HSTS should not be present for HTTP
         assert "strict-transport-security" not in response.headers
 
-    def test_hsts_default_max_age(self, app, client):
-        """Test HSTS uses default max-age of 1 year."""
-        app.add_middleware(SecurityHeadersMiddleware)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
-
-        response = client.get("/test", headers={"X-Forwarded-Proto": "https"})
-
-        assert response.headers["strict-transport-security"] == "max-age=31536000; includeSubDomains"
-
     def test_custom_headers_override_defaults(self, app, client):
-        """Test that custom headers completely override default headers."""
+        """Custom headers should completely replace defaults."""
         custom_headers = {
             "Cache-Control": "no-cache",
-            "Content-Security-Policy": "default-src 'self'",
             "X-Custom-Header": "custom-value",
         }
         app.add_middleware(SecurityHeadersMiddleware, headers=custom_headers)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test")
 
-        # Verify custom headers are used
         assert response.headers["cache-control"] == "no-cache"
-        assert response.headers["content-security-policy"] == "default-src 'self'"
-        assert "x-custom-header" in response.headers
         assert response.headers["x-custom-header"] == "custom-value"
-
-        # Verify default headers are NOT present when custom headers are provided
         assert "referrer-policy" not in response.headers
         assert "permissions-policy" not in response.headers
-        assert "x-frame-options" not in response.headers
 
     def test_no_duplicate_headers(self, app, client):
-        """Test that security headers are not duplicated."""
+        """Each security header should appear exactly once."""
         app.add_middleware(SecurityHeadersMiddleware)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test")
+        header_counts = Counter(key.lower() for key in response.headers.keys())
 
-        # Check that each security header appears only once
-        header_names = [key.lower() for key in response.headers.keys()]
-        header_counts = Counter(header_names)
+        for header in self.DEFAULT_HEADERS.keys():
+            assert header_counts[header] == 1
 
-        security_headers = [
-            "cache-control",
-            "content-security-policy",
-            "x-content-type-options",
-            "x-frame-options",
-            "referrer-policy",
-            "permissions-policy",
-        ]
-
-        for header in security_headers:
-            assert header_counts[header] == 1, f"Header {header} appears {header_counts[header]} times"
-
-    def test_respects_existing_headers_from_route(self, app, client):
-        """Test that middleware respects headers already set by the route."""
+    def test_respects_route_headers(self, app, client):
+        """Middleware should not override headers set by routes."""
         app.add_middleware(SecurityHeadersMiddleware)
 
-        @app.get("/test")
-        def test_route():
+        def handler():
             return JSONResponse(content={"status": "ok"}, headers={"Cache-Control": "public, max-age=3600"})
 
+        add_route(app, handler=handler)
         response = client.get("/test")
 
-        # Route's cache-control should be preserved (not overridden)
         assert response.headers["cache-control"] == "public, max-age=3600"
-
-        # Other security headers should still be added
         assert "content-security-policy" in response.headers
-        assert "x-content-type-options" in response.headers
-        assert "referrer-policy" in response.headers
 
-    def test_hsts_not_duplicated_when_already_present(self, app, client):
-        """Test HSTS is not added if already present in response."""
-        app.add_middleware(SecurityHeadersMiddleware)
 
-        @app.get("/test")
-        def test_route():
-            return JSONResponse(content={"status": "ok"}, headers={"Strict-Transport-Security": "max-age=99999"})
-
-        response = client.get("/test", headers={"X-Forwarded-Proto": "https"})
-
-        # Should keep the route's HSTS value
-        assert response.headers["strict-transport-security"] == "max-age=99999"
-
-        # Verify no duplicate HSTS headers
-        hsts_count = sum(1 for k in response.headers.keys() if k.lower() == "strict-transport-security")
-        assert hsts_count == 1
+# ============================================================================
+# Logging Middleware Tests
+# ============================================================================
 
 
 class TestLoggingMiddleware:
     """Test Logging middleware."""
 
-    def test_logs_request_and_response(self, app, client, caplog):
-        """Test that middleware logs both request start and completion."""
-        app.add_middleware(LoggingMiddleware, logger_name="test_logger")
+    LOGGER_NAME = "test_logger"
 
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+    def test_logs_request_lifecycle(self, app, client, caplog):
+        """Middleware should log request start and completion."""
+        app.add_middleware(LoggingMiddleware, logger_name=self.LOGGER_NAME)
+        add_route(app)
 
-        with caplog.at_level(logging.INFO, logger="test_logger"):
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
             response = client.get("/test?param=value")
 
         assert response.status_code == 200
+        logs = get_logs(caplog, self.LOGGER_NAME)
 
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        assert any("Request started" in msg for msg in log_messages)
-        assert any("Request completed" in msg for msg in log_messages)
-
-        # Verify request details are logged
-        started_msg = next(msg for msg in log_messages if "Request started" in msg)
-        assert "/test" in started_msg
-        assert "GET" in started_msg
+        assert any("Request started" in msg and "GET" in msg for msg in logs)
+        assert any("Request completed" in msg for msg in logs)
 
     def test_logs_process_time(self, app, client, caplog):
-        """Test that process time is included in logs."""
-        app.add_middleware(LoggingMiddleware, logger_name="test_logger")
+        """Process time should be included in completion logs."""
+        app.add_middleware(LoggingMiddleware, logger_name=self.LOGGER_NAME)
+        add_route(app)
 
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            client.get("/test")
 
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/test")
-
-        assert response.status_code == 200
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        completed_msg = next(msg for msg in log_messages if "Request completed" in msg)
-        assert "process_time" in completed_msg
+        completed_logs = get_logs(caplog, self.LOGGER_NAME, "Request completed")
+        assert any("process_time" in msg for msg in completed_logs)
 
     def test_skips_configured_paths(self, app, client, caplog):
-        """Test that configured paths are not logged."""
-        app.add_middleware(LoggingMiddleware, logger_name="test_logger", skip_paths=["/health", "/metrics"])
+        """Configured paths should not be logged."""
+        app.add_middleware(LoggingMiddleware, logger_name=self.LOGGER_NAME, skip_paths=["/health", "/metrics"])
+        add_route(app, "/health")
+        add_route(app, "/test")
 
-        @app.get("/health")
-        def health_route():
-            return {"status": "ok"}
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            client.get("/health")
+            client.get("/test")
 
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
-
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            health_response = client.get("/health")
-            test_response = client.get("/test")
-
-        assert health_response.status_code == 200
-        assert test_response.status_code == 200
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-
-        # /health should not be logged
-        assert not any("/health" in msg for msg in log_messages)
-
-        # /test should be logged
-        assert any("/test" in msg for msg in log_messages)
+        logs = get_logs(caplog, self.LOGGER_NAME)
+        assert not any("/health" in msg for msg in logs)
+        assert any("/test" in msg for msg in logs)
 
     def test_logs_errors_with_warning_level(self, app, client, caplog):
-        """Test that error responses are logged with warning level."""
+        """Error responses should be logged at WARNING level."""
         app.add_middleware(ErrorHandlingMiddleware)
-        app.add_middleware(LoggingMiddleware, logger_name="test_logger")
+        app.add_middleware(LoggingMiddleware, logger_name=self.LOGGER_NAME)
+        add_error_route(app, HTTPException(status_code=500, detail="Server error"))
 
-        @app.get("/error")
-        def error_route():
-            raise HTTPException(status_code=500, detail="Server error")
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            client.get("/error")
 
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/error")
-
-        assert response.status_code == 500
-
-        # Find the completion log record
         completion_records = [
-            record
-            for record in caplog.records
-            if record.name == "test_logger" and "Request completed" in record.message
+            r for r in caplog.records if r.name == self.LOGGER_NAME and "Request completed" in r.message
         ]
+        assert any(r.levelname == "WARNING" for r in completion_records)
 
-        assert len(completion_records) > 0
-        # Error responses should use warning level
-        assert any(record.levelname == "WARNING" for record in completion_records)
+
+# ============================================================================
+# Streaming Response Logging Tests
+# ============================================================================
 
 
 class TestStreamingResponseLogging:
     """Test streaming response body logging."""
 
-    def test_logs_streaming_response_body(self, app, client, caplog):
-        """Test that streaming response body is logged when enabled."""
-        app.add_middleware(
-            LoggingMiddleware,
-            logger_name="test_logger",
-            log_response_body=True,
-        )
+    LOGGER_NAME = "test_logger"
+
+    def setup_streaming_route(self, app, chunks: list[bytes], media_type: str = "text/plain"):
+        """Setup a streaming response route."""
 
         async def generate():
-            yield b"Hello "
-            yield b"World"
-            yield b"!"
+            for chunk in chunks:
+                yield chunk
 
         @app.get("/stream")
         def stream_route():
-            return StreamingResponse(generate(), media_type="text/plain")
+            return StreamingResponse(generate(), media_type=media_type)
 
-        with caplog.at_level(logging.INFO, logger="test_logger"):
+    def test_logs_streaming_body_when_enabled(self, app, client, caplog):
+        """Streaming response body should be logged when enabled."""
+        app.add_middleware(
+            LoggingMiddleware,
+            logger_name=self.LOGGER_NAME,
+            log_response_body=True,
+        )
+        self.setup_streaming_route(app, [b"Hello ", b"World", b"!"])
+
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
             response = client.get("/stream")
 
-        assert response.status_code == 200
         assert response.text == "Hello World!"
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        body_logs = [msg for msg in log_messages if "Response body:" in msg]
+        body_logs = get_logs(caplog, self.LOGGER_NAME, "Response body:")
 
         assert len(body_logs) == 1
         assert "Hello World!" in body_logs[0]
 
-    def test_does_not_log_body_when_disabled(self, app, client, caplog):
-        """Test that response body is NOT logged when disabled (default)."""
-        app.add_middleware(LoggingMiddleware, logger_name="test_logger")
+    def test_does_not_log_body_by_default(self, app, client, caplog):
+        """Response body should not be logged by default."""
+        app.add_middleware(LoggingMiddleware, logger_name=self.LOGGER_NAME)
+        self.setup_streaming_route(app, [b"Hello ", b"World"])
 
-        async def generate():
-            yield b"Hello "
-            yield b"World"
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            client.get("/stream")
 
-        @app.get("/stream")
-        def stream_route():
-            return StreamingResponse(generate(), media_type="text/plain")
-
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/stream")
-
-        assert response.status_code == 200
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        body_logs = [msg for msg in log_messages if "Response body:" in msg]
-
+        body_logs = get_logs(caplog, self.LOGGER_NAME, "Response body:")
         assert len(body_logs) == 0
 
-    def test_truncates_long_response_body(self, app, client, caplog):
-        """Test that long response bodies are truncated."""
+    def test_truncates_long_bodies(self, app, client, caplog):
+        """Long response bodies should be truncated."""
         app.add_middleware(
             LoggingMiddleware,
-            logger_name="test_logger",
+            logger_name=self.LOGGER_NAME,
             log_response_body=True,
             max_body_length=50,
         )
 
         long_text = "x" * 200
+        chunks = [long_text[i : i + 20].encode() for i in range(0, len(long_text), 20)]
+        self.setup_streaming_route(app, chunks)
 
-        async def generate():
-            chunk_size = 20
-            for i in range(0, len(long_text), chunk_size):
-                yield long_text[i : i + chunk_size].encode()
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            client.get("/stream")
 
-        @app.get("/stream")
-        def stream_route():
-            return StreamingResponse(generate(), media_type="text/plain")
-
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/stream")
-
-        assert response.status_code == 200
-        assert len(response.text) == 200
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        body_logs = [msg for msg in log_messages if "Response body:" in msg]
-
-        assert len(body_logs) == 1
+        body_logs = get_logs(caplog, self.LOGGER_NAME, "Response body:")
         assert "truncated" in body_logs[0]
         assert "full_length" in body_logs[0]
 
-    def test_logs_json_streaming_response(self, app, client, caplog):
-        """Test logging of JSON streaming responses."""
+    def test_logs_json_streaming(self, app, client, caplog):
+        """JSON streaming responses should be logged correctly."""
         app.add_middleware(
             LoggingMiddleware,
-            logger_name="test_logger",
+            logger_name=self.LOGGER_NAME,
             log_response_body=True,
         )
+        chunks = [b'{"items": [', b'{"id": 1}, ', b'{"id": 2}', b"]}"]
+        self.setup_streaming_route(app, chunks, media_type="application/json")
 
-        async def generate():
-            yield b'{"items": ['
-            yield b'{"id": 1}, '
-            yield b'{"id": 2}'
-            yield b"]}"
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            client.get("/stream")
 
-        @app.get("/stream")
-        def stream_route():
-            return StreamingResponse(generate(), media_type="application/json")
-
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/stream")
-
-        assert response.status_code == 200
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        body_logs = [msg for msg in log_messages if "Response body:" in msg]
-
-        import json
-
+        body_logs = get_logs(caplog, self.LOGGER_NAME, "Response body:")
         log_json = json.loads(body_logs[0].replace("Response body: ", ""))
+
         assert log_json["body"] == '{"items": [{"id": 1}, {"id": 2}]}'
 
-    def test_skips_binary_content_logging(self, app, client, caplog):
-        """Test that binary content is not logged (only size is logged)."""
+    def test_handles_binary_content(self, app, client, caplog):
+        """Binary content should not be logged (only metadata)."""
         app.add_middleware(
             LoggingMiddleware,
-            logger_name="test_logger",
+            logger_name=self.LOGGER_NAME,
             log_response_body=True,
         )
-
         binary_data = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        self.setup_streaming_route(app, [binary_data], media_type="image/png")
 
-        async def generate():
-            yield binary_data
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            client.get("/stream")
 
-        @app.get("/stream")
-        def stream_route():
-            return StreamingResponse(generate(), media_type="image/png")
-
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/stream")
-
-        assert response.status_code == 200
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        body_logs = [msg for msg in log_messages if "Response body" in msg]
-
-        assert len(body_logs) == 1
-        # Should log size and content type, not the actual binary data
+        body_logs = get_logs(caplog, self.LOGGER_NAME, "Response body")
         assert "binary" in body_logs[0]
         assert "image/png" in body_logs[0]
         assert "size" in body_logs[0]
 
-    def test_logs_regular_response_body(self, app, client, caplog):
-        """Test that regular (non-streaming) responses are also logged."""
+    def test_handles_unicode(self, app, client, caplog):
+        """Unicode characters should be logged correctly."""
         app.add_middleware(
             LoggingMiddleware,
-            logger_name="test_logger",
+            logger_name=self.LOGGER_NAME,
             log_response_body=True,
         )
+        chunks = ["Hello 世界 ".encode(), "🚀 Emoji".encode()]
+        self.setup_streaming_route(app, chunks, media_type="text/plain; charset=utf-8")
 
-        @app.get("/regular")
-        def regular_route():
-            return {"message": "Hello World"}
+        with caplog.at_level(logging.INFO, logger=self.LOGGER_NAME):
+            client.get("/stream")
 
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/regular")
-
-        assert response.status_code == 200
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        body_logs = [msg for msg in log_messages if "Response body:" in msg]
-
-        assert len(body_logs) == 1
-        assert "Hello World" in body_logs[0]
-
-    def test_handles_empty_streaming_response(self, app, client, caplog):
-        """Test handling of empty streaming responses."""
-        app.add_middleware(
-            LoggingMiddleware,
-            logger_name="test_logger",
-            log_response_body=True,
-        )
-
-        async def generate():
-            # Empty generator
-            return
-            yield
-
-        @app.get("/stream")
-        def stream_route():
-            return StreamingResponse(generate(), media_type="text/plain")
-
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/stream")
-
-        assert response.status_code == 200
-
-        # Should not crash, just not log anything for body
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        # Request started and completed should still be logged
-        assert any("Request started" in msg for msg in log_messages)
-        assert any("Request completed" in msg for msg in log_messages)
-
-    def test_handles_unicode_in_streaming_response(self, app, client, caplog):
-        """Test handling of unicode characters in streaming responses."""
-        app.add_middleware(
-            LoggingMiddleware,
-            logger_name="test_logger",
-            log_response_body=True,
-        )
-
-        async def generate():
-            yield "Hello 世界 ".encode()
-            yield "🚀 Emoji".encode()
-
-        @app.get("/stream")
-        def stream_route():
-            return StreamingResponse(generate(), media_type="text/plain; charset=utf-8")
-
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/stream")
-
-        assert response.status_code == 200
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        body_logs = [msg for msg in log_messages if "Response body:" in msg]
-
-        assert len(body_logs) == 1
+        body_logs = get_logs(caplog, self.LOGGER_NAME, "Response body:")
         assert "Hello 世界" in body_logs[0]
         assert "🚀 Emoji" in body_logs[0]
 
-    def test_logs_large_ai_response(self, app, client, caplog):
-        """Test logging of large AI/LLM streaming responses (real-world use case)."""
-        app.add_middleware(
-            LoggingMiddleware,
-            logger_name="test_logger",
-            log_response_body=True,
-            max_body_length=500,  # Limit for large responses
-        )
 
-        ai_response = "This is a simulated LLM/AI/ML response. " * 50  # ~1500 chars
-
-        async def generate():
-            # Stream word by word (like LLM streaming)
-            words = ai_response.split()
-            for word in words:
-                yield (word + " ").encode()
-
-        @app.get("/ai/chat")
-        def ai_chat():
-            return StreamingResponse(generate(), media_type="text/plain")
-
-        with caplog.at_level(logging.INFO, logger="test_logger"):
-            response = client.get("/ai/chat")
-
-        assert response.status_code == 200
-        assert len(response.text) > 1000
-
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        body_logs = [msg for msg in log_messages if "Response body:" in msg]
-
-        assert len(body_logs) == 1
-        # Should be truncated
-        assert "truncated" in body_logs[0]
-        assert "full_length" in body_logs[0]
-        # But should still contain the beginning
-        assert "This is a simulated LLM/AI/ML response" in body_logs[0]
+# ============================================================================
+# ErrorHandling Middleware Tests
+# ============================================================================
 
 
 class TestErrorHandlingMiddleware:
     """Test ErrorHandling middleware."""
 
     def test_catches_value_error(self, app, client):
-        """Test that middleware catches ValueError exceptions."""
+        """ValueError should be caught and formatted."""
         app.add_middleware(ErrorHandlingMiddleware)
-
-        @app.get("/error")
-        def error_route():
-            raise ValueError("Test error message")
+        add_error_route(app, ValueError("Test error message"))
 
         response = client.get("/error")
 
@@ -706,13 +498,10 @@ class TestErrorHandlingMiddleware:
         assert data["message"] == "Test error message"
         assert "request_id" in data
 
-    def test_catches_generic_exception(self, app, client):
-        """Test that middleware catches any exception."""
+    def test_catches_generic_exceptions(self, app, client):
+        """Any exception should be caught and formatted."""
         app.add_middleware(ErrorHandlingMiddleware)
-
-        @app.get("/error")
-        def error_route():
-            raise RuntimeError("Runtime error")
+        add_error_route(app, RuntimeError("Runtime error"))
 
         response = client.get("/error")
 
@@ -722,262 +511,178 @@ class TestErrorHandlingMiddleware:
         assert data["message"] == "Runtime error"
 
     def test_includes_traceback_when_enabled(self, app, client):
-        """Test that traceback is included when enabled."""
+        """Traceback should be included when explicitly enabled."""
         app.add_middleware(ErrorHandlingMiddleware, include_traceback=True)
-
-        @app.get("/error")
-        def error_route():
-            raise ValueError("Test error")
+        add_error_route(app, ValueError("Test error"))
 
         response = client.get("/error")
-
         data = response.json()
+
         assert "traceback" in data
         assert "ValueError" in data["traceback"]
-        assert "Test error" in data["traceback"]
 
     def test_excludes_traceback_by_default(self, app, client):
-        """Test that traceback is not included by default."""
+        """Traceback should be excluded by default."""
         app.add_middleware(ErrorHandlingMiddleware)
-
-        @app.get("/error")
-        def error_route():
-            raise ValueError("Test error")
+        add_error_route(app, ValueError("Test error"))
 
         response = client.get("/error")
 
-        data = response.json()
-        assert "traceback" not in data
+        assert "traceback" not in response.json()
 
-    def test_preserves_http_exception_status_code(self, app, client):
-        """Test that HTTP exception status codes are preserved."""
+    def test_preserves_http_exception_codes(self, app, client):
+        """HTTP exception status codes should be preserved."""
         app.add_middleware(ErrorHandlingMiddleware)
 
         @app.get("/not-found")
-        def not_found_route():
-            raise HTTPException(status_code=404, detail="Resource not found")
+        def not_found():
+            raise HTTPException(status_code=404, detail="Not found")
 
         @app.get("/unauthorized")
-        def unauthorized_route():
+        def unauthorized():
             raise HTTPException(status_code=401, detail="Unauthorized")
 
-        response_404 = client.get("/not-found")
-        assert response_404.status_code == 404
-
-        response_401 = client.get("/unauthorized")
-        assert response_401.status_code == 401
+        assert client.get("/not-found").status_code == 404
+        assert client.get("/unauthorized").status_code == 401
 
     def test_custom_error_handler(self, app, client):
-        """Test that custom error handlers work."""
+        """Custom error handlers should be used when registered."""
 
         async def handle_value_error(scope, exc):
             return JSONResponse(status_code=400, content={"custom_error": "bad_request", "details": str(exc)})
 
         app.add_middleware(ErrorHandlingMiddleware, custom_handlers={ValueError: handle_value_error})
-
-        @app.get("/error")
-        def error_route():
-            raise ValueError("Invalid input")
+        add_error_route(app, ValueError("Invalid input"))
 
         response = client.get("/error")
 
         assert response.status_code == 400
         data = response.json()
         assert data["custom_error"] == "bad_request"
-        assert data["details"] == "Invalid input"
 
-    def test_includes_request_id_in_error(self, app, client):
-        """Test that request ID is included in error response."""
-        app.add_middleware(ErrorHandlingMiddleware)
-        app.add_middleware(RequestIDMiddleware)
 
-        @app.get("/error")
-        def error_route():
-            raise ValueError("Test error")
-
-        response = client.get("/error")
-
-        data = response.json()
-        assert "request_id" in data
-        assert data["request_id"] != "N/A"
+# ============================================================================
+# Helper Function Tests
+# ============================================================================
 
 
 class TestHelperFunctions:
     """Test helper functions."""
 
-    def test_add_cors_with_origins(self, app, client):
-        """Test CORS middleware with specific origins."""
+    def test_add_cors_with_specific_origins(self, app, client):
+        """CORS should work with specific allowed origins."""
         add_cors(app, allow_origins=["http://localhost:3000"])
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test", headers={"Origin": "http://localhost:3000"})
 
-        assert response.status_code == 200
         assert "access-control-allow-origin" in response.headers
 
     def test_add_cors_with_wildcard(self, app, client):
-        """Test CORS middleware with wildcard origin."""
-        add_cors(app)  # Default is ["*"]
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        """CORS should work with wildcard origin."""
+        add_cors(app)
+        add_route(app)
 
         response = client.get("/test", headers={"Origin": "http://example.com"})
 
-        assert response.status_code == 200
         assert "access-control-allow-origin" in response.headers
 
-    def test_add_gzip_compression(self, app, client):
-        """Test GZip compression middleware."""
+    def test_add_gzip(self, app, client):
+        """GZip compression should be enabled."""
         add_gzip(app)
 
         @app.get("/test")
-        def test_route():
-            # Return large response to trigger compression
+        def handler():
             return {"status": "ok", "data": "x" * 2000}
 
         response = client.get("/test", headers={"Accept-Encoding": "gzip"})
 
         assert response.status_code == 200
-        # Content should be returned (TestClient handles decompression)
 
-    def test_add_essentials_includes_all_middlewares(self, app, client, caplog):
-        """Test that add_essentials includes all essential middlewares."""
+    def test_add_essentials_includes_all(self, app, client, caplog):
+        """add_essentials should enable all essential middlewares."""
         add_essentials(app, cors_origins=["http://localhost:3000"])
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         with caplog.at_level(logging.INFO, logger="fastapi_middlewares"):
             response = client.get("/test")
 
-        assert response.status_code == 200
-
-        # Verify all middleware headers are present
+        # Check middleware headers
         assert "x-request-id" in response.headers
         assert "x-process-time" in response.headers
         assert "x-content-type-options" in response.headers
-        assert "cache-control" in response.headers
 
-        # Verify logging happened
-        log_messages = [record.message for record in caplog.records if record.name == "fastapi_middlewares"]
-        assert any("Request started" in msg for msg in log_messages)
+        # Check logging
+        logs = get_logs(caplog, "fastapi_middlewares", "Request started")
+        assert len(logs) > 0
 
     def test_add_essentials_with_custom_logger(self, app, client, caplog):
-        """Test add_essentials with custom logger name."""
+        """add_essentials should support custom logger names."""
         add_essentials(app, logger_name="custom_logger")
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         with caplog.at_level(logging.INFO, logger="custom_logger"):
-            response = client.get("/test")
+            client.get("/test")
 
-        assert response.status_code == 200
-
-        log_messages = [record.message for record in caplog.records if record.name == "custom_logger"]
-        assert len(log_messages) > 0
+        assert len(get_logs(caplog, "custom_logger")) > 0
 
     def test_add_essentials_without_gzip(self, app, client):
-        """Test add_essentials with gzip disabled."""
+        """add_essentials should allow disabling gzip."""
         add_essentials(app, enable_gzip=False)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         response = client.get("/test")
 
-        assert response.status_code == 200
-        # Other middlewares should still work
         assert "x-request-id" in response.headers
 
 
+# ============================================================================
+# Integration Tests
+# ============================================================================
+
+
 class TestMiddlewareIntegration:
-    """Test all middlewares working together."""
+    """Test middleware integration and ordering."""
 
     def test_all_middlewares_together(self, app, client, caplog):
-        """Test that all middlewares work together without conflicts."""
+        """All middlewares should work together without conflicts."""
         app.add_middleware(ErrorHandlingMiddleware)
         app.add_middleware(LoggingMiddleware, logger_name="test_logger")
         app.add_middleware(RequestTimingMiddleware)
         app.add_middleware(SecurityHeadersMiddleware)
         app.add_middleware(RequestIDMiddleware)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         with caplog.at_level(logging.INFO, logger="test_logger"):
             response = client.get("/test")
 
         assert response.status_code == 200
+        assert all(
+            h in response.headers for h in ["x-request-id", "x-process-time", "x-content-type-options", "cache-control"]
+        )
 
-        # Verify all middleware features work
-        assert "x-request-id" in response.headers
-        assert "x-process-time" in response.headers
-        assert "x-content-type-options" in response.headers
-        assert "cache-control" in response.headers
+        logs = get_logs(caplog, "test_logger")
+        assert any("Request started" in msg for msg in logs)
 
-        log_messages = [record.message for record in caplog.records if record.name == "test_logger"]
-        assert any("Request started" in msg for msg in log_messages)
-        assert any("Request completed" in msg for msg in log_messages)
-
-    def test_error_handling_with_all_middlewares(self, app, client, caplog):
-        """Test that error handling works with all middlewares active."""
+    def test_error_handling_with_full_stack(self, app, client):
+        """Error handling should work with all middlewares active."""
         app.add_middleware(ErrorHandlingMiddleware, include_traceback=True)
         app.add_middleware(LoggingMiddleware, logger_name="test_logger")
         app.add_middleware(RequestTimingMiddleware)
         app.add_middleware(SecurityHeadersMiddleware)
         app.add_middleware(RequestIDMiddleware)
+        add_error_route(app, ValueError("Test error"))
 
-        @app.get("/error")
-        def error_route():
-            raise ValueError("Test error")
-
-        with caplog.at_level(logging.ERROR):
-            response = client.get("/error")
+        response = client.get("/error")
 
         assert response.status_code == 500
         data = response.json()
         assert data["error"] == "ValueError"
         assert "traceback" in data
+        assert all(h in response.headers for h in ["x-request-id", "x-process-time", "x-content-type-options"])
 
-        # Verify all middleware headers are still present on error
-        assert "x-request-id" in response.headers
-        assert "x-process-time" in response.headers
-        assert "x-content-type-options" in response.headers
-
-        # Verify error was logged
-        log_messages = [record.message for record in caplog.records]
-        assert any("failed" in msg.lower() or "error" in msg.lower() for msg in log_messages)
-
-    def test_middleware_ordering_matters(self, app, client):
-        """Test that middleware ordering affects behavior (request ID in error response)."""
-        # Add RequestIDMiddleware AFTER ErrorHandlingMiddleware (wrong order)
-        app.add_middleware(RequestIDMiddleware)
-        app.add_middleware(ErrorHandlingMiddleware)
-
-        @app.get("/error")
-        def error_route():
-            raise ValueError("Test error")
-
-        response = client.get("/error")
-
-        data = response.json()
-        # Request ID should still be present because RequestIDMiddleware runs first
-        assert "request_id" in data
-        assert data["request_id"] != "N/A"
-
-    def test_correct_middleware_order(self, app, client, caplog):
-        """Test recommended middleware ordering."""
-        # Recommended order: outermost to innermost
+    def test_recommended_middleware_order(self, app, client, caplog):
+        """Test recommended middleware ordering (outermost to innermost)."""
         add_gzip(app)
         app.add_middleware(LoggingMiddleware, logger_name="test_logger")
         app.add_middleware(RequestTimingMiddleware)
@@ -985,15 +690,10 @@ class TestMiddlewareIntegration:
         app.add_middleware(SecurityHeadersMiddleware)
         add_cors(app)
         app.add_middleware(ErrorHandlingMiddleware)
-
-        @app.get("/test")
-        def test_route():
-            return {"status": "ok"}
+        add_route(app)
 
         with caplog.at_level(logging.INFO, logger="test_logger"):
             response = client.get("/test")
 
         assert response.status_code == 200
-        assert "x-request-id" in response.headers
-        assert "x-process-time" in response.headers
-        assert "x-content-type-options" in response.headers
+        assert all(h in response.headers for h in ["x-request-id", "x-process-time", "x-content-type-options"])

--- a/uv.lock
+++ b/uv.lock
@@ -54,6 +54,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cf/72/f704a97aac430aeb704fa16435dfa24fbeaf087d46724d0965eb1f756a2c/bandit-1.9.2.tar.gz", hash = "sha256:32410415cd93bf9c8b91972159d5cf1e7f063a9146d70345641cd3877de348ce", size = 4241659, upload-time = "2025-11-23T21:36:18.722Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/1a/5b0320642cca53a473e79c7d273071b5a9a8578f9e370b74da5daa2768d7/bandit-1.9.2-py3-none-any.whl", hash = "sha256:bda8d68610fc33a6e10b7a8f1d61d92c8f6c004051d5e946406be1fb1b16a868", size = 134377, upload-time = "2025-11-23T21:36:17.39Z" },
+]
+
+[[package]]
 name = "build"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -435,6 +450,7 @@ name = "fastapi-middlewares"
 version = "0.1.1"
 source = { editable = "." }
 dependencies = [
+    { name = "bandit" },
     { name = "build" },
     { name = "fastapi" },
     { name = "starlette" },
@@ -454,6 +470,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "bandit", specifier = ">=1.9.2" },
     { name = "build", specifier = ">=1.3.0" },
     { name = "fastapi", specifier = ">=0.121.0" },
     { name = "starlette", specifier = ">=0.50.0" },
@@ -1210,6 +1227,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/b8/73a0e6a6e079a9d9cfa64113d771e421640b6f679a52eeb9b32f72d871a1/starlette-0.50.0.tar.gz", hash = "sha256:a2a17b22203254bcbc2e1f926d2d55f3f9497f769416b3190768befe598fa3ca", size = 2646985, upload-time = "2025-11-01T15:25:27.516Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d9/52/1064f510b141bd54025f9b55105e26d1fa970b9be67ad766380a3c9b74b0/starlette-0.50.0-py3-none-any.whl", hash = "sha256:9e5391843ec9b6e472eed1365a78c8098cfceb7a74bfd4d6b1c0c0095efb3bca", size = 74033, upload-time = "2025-11-01T15:25:25.461Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/5b/496f8abebd10c3301129abba7ddafd46c71d799a70c44ab080323987c4c9/stevedore-5.6.0.tar.gz", hash = "sha256:f22d15c6ead40c5bbfa9ca54aa7e7b4a07d59b36ae03ed12ced1a54cf0b51945", size = 516074, upload-time = "2025-11-20T10:06:07.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/40/8561ce06dc46fd17242c7724ab25b257a2ac1b35f4ebf551b40ce6105cfa/stevedore-5.6.0-py3-none-any.whl", hash = "sha256:4a36dccefd7aeea0c70135526cecb7766c4c84c473b1af68db23d541b6dc1820", size = 54428, upload-time = "2025-11-20T10:06:05.946Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds streaming response body logging functionality to the LoggingMiddleware, enabling complete response body capture after streaming completes. This is particularly useful for AI/LLM applications where streaming responses need to be logged for debugging and monitoring purposes.

Key Changes:

Added log_response_body and max_body_length parameters to LoggingMiddleware
Implemented response body buffering and logging for streaming responses
Added comprehensive test coverage for the new streaming functionality
Updated documentation and examples to showcase the new feature